### PR TITLE
Fix under-sampling issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A seleção de atributos agora utiliza o algoritmo Sequential Forward Floating S
 Além disso, o workflow aplica redução de dimensionalidade via PCA antes do
 ajuste dos modelos.
 
-O balanceamento das classes agora utiliza o `RandomUnderSampler` da
-biblioteca *imbalanced-learn*, reduzindo a maioria para 30.000 instâncias
-e mantendo 38.694 e 3.452 amostras nas demais classes.
+O balanceamento das classes utiliza o `RandomUnderSampler` da
+biblioteca *imbalanced-learn*. Os valores-alvo (30.000, 38.694 e 3.452
+amostras) são ajustados automaticamente para nunca exceder o número de
+amostras disponíveis após a divisão do conjunto de treino.


### PR DESCRIPTION
## Summary
- ensure RandomUnderSampler never requests more samples than available
- document the new dynamic sampling strategy

## Testing
- `python3 -m py_compile workflow3.py sffs.py`
- `python3 - <<'PY'
from workflow3 import compute_sampling_strategy
import pandas as pd
counts = [0]*100 + [1]*500 + [2]*20
print(compute_sampling_strategy(pd.Series(counts)))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684e1d104c0c832c8c2e246de638e039