### PR TITLE
Add sampling strategy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ O script inclui também uma implementação simplificada de um classificador do
 tipo *RBF Network*, baseado em K-Means e regressão logística, que é otimizado
 junto aos demais modelos.
 
-O balanceamento das classes utiliza o `RandomUnderSampler` da
-biblioteca *imbalanced-learn*. Os valores-alvo (30.000, 38.694 e 3.452
-amostras) são ajustados automaticamente para nunca exceder o número de
-amostras disponíveis após a divisão do conjunto de treino.
+O balanceamento das classes pode ser feito por `RandomUnderSampler` ou
+`SMOTE`, ambos da biblioteca *imbalanced-learn*. Os valores-alvo (30.000,
+38.694 e 3.452 amostras) são ajustados automaticamente para nunca exceder o
+número de amostras disponíveis após a divisão do conjunto de treino no caso de
+subamostragem.
+Para definir qual deles será usado, altere a variável `SAMPLER_TYPE` em
+`workflow3.py` para `"under"` ou `"smote"`.


### PR DESCRIPTION
## Summary
- support choosing `SMOTE` or `RandomUnderSampler` for class balancing
- document sampler choice in README

## Testing
- `python3 -m py_compile workflow3.py sffs.py`
- `flake8` *(fails: numerous style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68506e36eaf0832cb7156ddf5d606f59