### PR TITLE
Centralize configuration

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,19 @@
+ROI = 'PA'
+FILE = 'df_pa.parquet'
+SAMPLER_TYPE = 'under'
+
+if ROI == 'PA':
+    SAMPLING_STRATEGY = {0: 24000, 1: 24000}
+elif ROI == 'TK':
+    SAMPLING_STRATEGY = {0: 3000, 1: 3000}
+else:
+    SAMPLING_STRATEGY = {0: 1000, 1: 1000}
+
+import os
+ROOT = os.path.dirname(os.path.abspath(__file__))
+DATA_PATH = os.path.join(ROOT, FILE)
+
+MODEL_DIR = os.path.join(ROOT, f"model_SFFS_{ROI}")
+MODEL_DIR_PCA = os.path.join(ROOT, f"model_PCA_{ROI}")
+FEATS_PATH = os.path.join(ROOT, f"selected_features_{ROI}.json")
+PCA_PATH = os.path.join(ROOT, f"pca_scaler_{ROI}.joblib")

--- a/predict_models.py
+++ b/predict_models.py
@@ -7,6 +7,11 @@ from joblib import load
 
 from workflow import load_data, split_data, final_predictions
 
+from config import (
+    ROI, DATA_PATH, MODEL_DIR, MODEL_DIR_PCA,
+    FEATS_PATH, PCA_PATH
+)
+
 
 def load_models(model_dir):
     models = {}
@@ -18,17 +23,7 @@ def load_models(model_dir):
 
 
 def main():
-    ROI = 'PA'
-    file = 'df_pa.parquet'
-
-    ROOT = os.getcwd()
-    MODEL_DIR = os.path.join(ROOT, f"model_SFFS_{ROI}")
-    MODEL_DIR_PCA = os.path.join(ROOT, f"model_PCA_{ROI}")
-    FEATS_PATH = os.path.join(ROOT, f"selected_features_{ROI}.json")
-    PCA_PATH = os.path.join(ROOT, f"pca_scaler_{ROI}.joblib")
-
-    path = os.path.join(ROOT, file)
-    df, X = load_data(path)
+    df, X = load_data(DATA_PATH)
     X_train, X_test, _, y_test, _, _ = split_data(df, test_size=0.9)
     _, _, _, _, X_full, y_full = split_data(X, test_size=0.9)
     

--- a/train.py
+++ b/train.py
@@ -28,38 +28,25 @@ from workflow import (
     run_model, evaluate_on_test, build_rbf_classifier
 )
 
+from config import (
+    ROI, SAMPLER_TYPE, SAMPLING_STRATEGY, DATA_PATH,
+    MODEL_DIR, MODEL_DIR_PCA, FEATS_PATH, PCA_PATH
+)
+
 from sklearnex import patch_sklearn
 patch_sklearn()
 
 
 
 def main():
-    SAMPLER_TYPE = 'under'
     fold = 5
     n_iter = 50
-    file = 'df_pa.parquet'
-    ROI = 'PA'
 
-    if ROI == 'PA':
-        SAMPLING_STRATEGY = {0: 24000, 1: 24000}
-    elif ROI == 'TK':
-        SAMPLING_STRATEGY = {0: 3000, 1: 3000}
-        
-    ROOT = os.getcwd()
-    MODEL_DIR = os.path.join(ROOT, f"model_SFFS_{ROI}")
-    MODEL_DIR_PCA = os.path.join(ROOT, f"model_PCA_{ROI}")
-    FEATS_PATH = os.path.join(ROOT, f"selected_features_{ROI}.json")
-    PCA_PATH = os.path.join(ROOT, f"pca_scaler_{ROI}.joblib")
-    
     os.makedirs(MODEL_DIR, exist_ok=True)
-    os.makedirs(MODEL_DIR_PCA, exist_ok=True)   
-    os.makedirs(FEATS_PATH, exist_ok=True)
-    os.makedirs(PCA_PATH, exist_ok=True)
-    
-    path = os.path.join(ROOT, file)
-    print(f"\n\nCarregando dados de {path}...\n\n")
-    
-    df, X  = load_data(path)
+    os.makedirs(MODEL_DIR_PCA, exist_ok=True)
+    print(f"\n\nCarregando dados de {DATA_PATH}...\n\n")
+
+    df, X  = load_data(DATA_PATH)
     
     print(f"Dados: {df.shape[0]} linhas, {df.shape[1]} colunas; classes:\n{df['label'].value_counts(normalize=True)}")
     print(f"Contagem:\n{X.groupby('label').count()}")

--- a/workflow.py
+++ b/workflow.py
@@ -34,26 +34,18 @@ from sffs import sffs
 import warnings
 from joblib import Memory, dump
 
+from config import (
+    ROI, SAMPLER_TYPE, SAMPLING_STRATEGY, DATA_PATH,
+    MODEL_DIR, MODEL_DIR_PCA
+)
+
 warnings.filterwarnings('ignore')
 
-
-SAMPLER_TYPE = 'under'
 fold = 5
 n_iter = 50
-file = 'df_pa.parquet'
-ROI = 'PA'
 
-if ROI == 'PA':
-    SAMPLING_STRATEGY = {0: 24000, 1: 24000}
-elif ROI == 'TK':
-    SAMPLING_STRATEGY = {0: 3000, 1: 3000}
-
-ROOT = os.getcwd()
-MODEL_DIR = os.path.join(ROOT,f"model_SFFS_{ROI}_filtered")
-MODEL_DIR_PCA = fr"/home/mira/recPadroes/model_PCA_{ROI}_filtered"
 os.makedirs(MODEL_DIR, exist_ok=True)
 os.makedirs(MODEL_DIR_PCA, exist_ok=True)
-
 
 print(f"\n\tUsando estratégia de amostragem {ROI}: \n\n\t{SAMPLING_STRATEGY}")
 
@@ -362,8 +354,7 @@ def build_rbf_classifier():
 
 def main():
     # 1. Carrega dados
-    path = os.path.join(ROOT, file)
-    df, X = load_data(path)
+    df, X = load_data(DATA_PATH)
     print(f"Dados: {df.shape[0]} linhas, {df.shape[1]} colunas; classes:\n{df['label'].value_counts(normalize=True)}")
 
     # 2. Divide treino/teste


### PR DESCRIPTION
## Summary
- simplify variable management across scripts
- centralize `ROI`, paths and sampler settings in `config.py`
- update training, workflow and prediction scripts to use the shared config
- fix incorrect directory creation and use script location for ROOT

## Testing
- `python -m py_compile config.py train.py workflow.py predict_models.py sffs.py`


------
https://chatgpt.com/codex/tasks/task_e_68656b044c9c832c930e60c265872728