### PR TITLE
Fix training output path handling

### DIFF
--- a/train.py
+++ b/train.py
@@ -44,8 +44,9 @@ def main():
 
     os.makedirs(MODEL_DIR, exist_ok=True)
     os.makedirs(MODEL_DIR_PCA, exist_ok=True)
-    os.makedirs(FEATS_PATH, exist_ok=True)
-    os.makedirs(PCA_PATH, exist_ok=True)
+    # ensure directories for output files exist
+    os.makedirs(os.path.dirname(FEATS_PATH) or '.', exist_ok=True)
+    os.makedirs(os.path.dirname(PCA_PATH) or '.', exist_ok=True)
     print(f"\n\nCarregando dados de {DATA_PATH}...\n\n")
 
     df, X  = load_data(DATA_PATH)


### PR DESCRIPTION
## Summary
- prevent `train.py` from treating output file paths as directories
- ensure parent directories exist before writing selected features and PCA files

## Testing
- `python -m py_compile train.py`
- `python -m py_compile workflow.py predict_models.py sffs.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_686575d6a248832c8816da206bdb4e38