### PR TITLE
Add training routine without feature selection

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,5 +15,6 @@ DATA_PATH = os.path.join(ROOT, FILE)
 
 MODEL_DIR = os.path.join(ROOT, f"model_SFFS_{ROI}")
 MODEL_DIR_PCA = os.path.join(ROOT, f"model_PCA_{ROI}")
+MODEL_DIR_FULL = os.path.join(ROOT, f"model_FULL_{ROI}")
 FEATS_PATH = os.path.join(ROOT, f"selected_features_{ROI}.json")
 PCA_PATH = os.path.join(ROOT, f"pca_scaler_{ROI}.joblib")

--- a/train.py
+++ b/train.py
@@ -30,11 +30,127 @@ from workflow import (
 
 from config import (
     ROI, SAMPLER_TYPE, SAMPLING_STRATEGY, DATA_PATH,
-    MODEL_DIR, MODEL_DIR_PCA, FEATS_PATH, PCA_PATH
+    MODEL_DIR, MODEL_DIR_PCA, MODEL_DIR_FULL,
+    FEATS_PATH, PCA_PATH
 )
 
 from sklearnex import patch_sklearn
 patch_sklearn()
+
+
+def main_no_fs():
+    """Train all models without feature selection or PCA."""
+    fold = 5
+    n_iter = 50
+
+    os.makedirs(MODEL_DIR_FULL, exist_ok=True)
+
+    df, X = load_data(DATA_PATH)
+
+    X_train, X_test, y_train, y_test, _, _ = split_data(df, test_size=0.5)
+
+    if SAMPLER_TYPE == 'smote':
+        sampling_strategy = None
+    else:
+        sampling_strategy = compute_sampling_strategy(y_train)
+
+    skf = StratifiedKFold(n_splits=fold, shuffle=True, random_state=123)
+    scorers = {
+        'accuracy': make_scorer(accuracy_score),
+        'f1_macro': make_scorer(f1_score, average='macro'),
+        'f1_weighted': make_scorer(f1_score, average='weighted'),
+        'recall_macro': make_scorer(recall_score, average='macro'),
+        'precision_macro': make_scorer(precision_score, average='macro'),
+        'kappa': make_scorer(cohen_kappa_score)
+    }
+
+    models = {
+        'SVM-Linear': (
+            SVC(kernel='linear', probability=True, random_state=42),
+            {
+                'model__C': uniform(1, 1000),
+                'model__gamma': [0.01, 0.05, 0.1, 0.5, 1, 1.5]
+            }
+        ),
+        'SVM-RBF': (
+            SVC(kernel='rbf', probability=True, random_state=42),
+            {
+                'model__C': uniform(1, 1000),
+                'model__gamma': [0.01, 0.05, 0.1, 0.5, 1, 1.5]
+            }
+        ),
+        'KNN': (
+            KNeighborsClassifier(),
+            {'model__n_neighbors': randint(1, 31)}
+        ),
+        'RF': (
+            RandomForestClassifier(random_state=42),
+            {
+                'model__n_estimators': randint(10, 200),
+                'model__max_depth': [2, 5, 10, 25, 50],
+                'model__max_features': ['auto','sqrt','log2'],
+                'model__min_impurity_decrease':  [0.001, 0.00001, 0.00001]
+            }
+        ),
+        'MLP': (
+            MLPClassifier(max_iter=1000, random_state=42),
+            {
+                'model__hidden_layer_sizes': [(50,), (100,), (50, 50), (100, 50), (100, 100)],
+                'model__alpha': 10.0 ** -np.arange(1, 5),
+                'model__learning_rate_init': [0.01, 0.001, 0.005],
+                'model__activation': ['relu', 'tanh', 'logistic']
+            }
+        ),
+        'AdaBoost': (
+            AdaBoostClassifier(random_state=42),
+            {
+                'model__n_estimators': randint(10, 250),
+                'model__learning_rate': [0.01, 0.001, 0.0001]
+            }
+        ),
+        'GNB': (GaussianNB(),
+                {'model__var_smoothing': [1e-6, 1e-7, 1e-8, 1e-9, 1e-10, 1e-11, 1e-12, 1e-13, 1e-14, 1e-15]}),
+        'RBF-Net': (
+            build_rbf_classifier(),
+            {
+                'model__n_clusters': randint(5, 61),
+                'model__epsilon': [0.1, 0.01, 0.5,1.0]
+            }
+        )
+    }
+
+    trained = {}
+    for name, (est, params) in models.items():
+        trained[name] = run_model(
+            name, est, params, X_train, y_train, skf, scorers, n_iter,
+            model_dir=MODEL_DIR_FULL,
+            sampling_strategy=sampling_strategy,
+            sampler_type=SAMPLER_TYPE
+        )
+
+    bag_base = RandomForestClassifier(n_estimators=50, max_depth=10, random_state=42)
+    bag = BaggingClassifier(estimator=bag_base, random_state=42)
+    trained['Bagging'] = run_model(
+        'Bagging', bag, {'model__n_estimators': [10,20,30,40,50]},
+        X_train, y_train, skf, scorers, n_iter, model_dir=MODEL_DIR_FULL,
+        sampling_strategy=sampling_strategy, sampler_type=SAMPLER_TYPE
+    )
+
+    stack = StackingClassifier(
+        estimators=[(n, trained[n]) for n in ['RF','RBF-Net','MLP','KNN'] if n in trained],
+        final_estimator=LogisticRegression(max_iter=1000, random_state=42),
+        cv=skf, n_jobs=1
+    )
+    trained['Stacking'] = run_model(
+        'Stacking', stack, {'final_estimator__C': np.logspace(-2, 1, 10)},
+        X_train, y_train, skf, scorers, n_iter, model_dir=MODEL_DIR_FULL,
+        sampling_strategy=sampling_strategy, sampler_type=SAMPLER_TYPE,
+        n_jobs=1
+    )
+
+    df_test_eval = evaluate_on_test(trained, X_test, y_test)
+    df_test_eval.to_csv(f'model_performance_test_FULL_{ROI}.csv', index=False)
+    print(df_test_eval.sort_values('F1_Macro', ascending=False).to_string(index=False))
 
 
 
@@ -218,4 +334,14 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Treina modelos")
+    parser.add_argument('--no-fs', action='store_true',
+                        help='Executa modelos sem SFFS ou PCA')
+    args = parser.parse_args()
+
+    if args.no_fs:
+        main_no_fs()
+    else:
+        main()


### PR DESCRIPTION
## Summary
- add `MODEL_DIR_FULL` for storing models trained without feature selection
- implement `main_no_fs` in `train.py` to train on all features
- provide CLI flag `--no-fs` to run new routine

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e8702311c832c943f8084ec110bef