### PR TITLE
Support predictions for full models

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Dois scripts foram adicionados:
 * `train_models.py` – treina os modelos, salva cada um em `model_SFFS_*` e
   `model_PCA_*` e grava as métricas de validação.
 * `predict_models.py` – carrega os modelos treinados, aplica as mesmas
-  transformações e gera um CSV com as previsões.
+  transformações e gera um CSV com as previsões. Use o parâmetro `--full`
+  para gerar previsões de modelos treinados com todas as features.
 
 Para acelerar os modelos do scikit-learn, o script utiliza a biblioteca
 `scikit-learn-intelex` (importada via `sklearnex`). Caso ela não esteja

--- a/predict_models.py
+++ b/predict_models.py
@@ -2,17 +2,20 @@
 # -*- coding: utf-8 -*-
 import os
 import json
+import argparse
 import pandas as pd
 from joblib import load
 
 from workflow import load_data, split_data, final_predictions
 
 from config import (
-    ROI, DATA_PATH, MODEL_DIR, MODEL_DIR_PCA,
+    ROI, DATA_PATH, MODEL_DIR, MODEL_DIR_PCA, MODEL_DIR_FULL,
     FEATS_PATH, PCA_PATH
 )
+
 path_pca = f'predictions_PCA_{ROI}_Filtered.csv'
 path_sffs = f'predictions_SFFS_{ROI}_Filtered.csv'
+path_full = f'predictions_FULL_{ROI}_Filtered.csv'
 
 def load_models(model_dir):
     models = {}
@@ -23,7 +26,7 @@ def load_models(model_dir):
     return models
 
 
-def main():
+def main(full=False):
     df, X = load_data(DATA_PATH)
     X_train, X_test, _, y_test, _, _ = split_data(df, test_size=0.9)
     _, _, _, _, X_full, y_full = split_data(X, test_size=0.9)
@@ -33,20 +36,31 @@ def main():
     print(f"Dados: {df.shape[0]} linhas, {df.shape[1]} colunas")
     
     print(f"cols {X_full.columns.tolist()}")
+
+    if full:
+        X_train_sel = X_train
+        X_test_sel = X_test
+        X_full_sel = X_full
+        models = load_models(MODEL_DIR_FULL)
+        print(f"\n\nModels loaded from {MODEL_DIR_FULL}:\n{list(models.keys())}\n\n")
+        final_predictions(df, X_full_sel, y_full, X_test_sel, y_test, models,
+                          top_n=10, output_csv=path_full)
+        return
+
     with open(FEATS_PATH) as f:
         selected_cols = json.load(f)
 
     print(f"features selected: {selected_cols}")
-    print(f'\n\n\nX_train: {X_train.columns.tolist()}\n\nX_test: {X_test.columns.tolist()}\n\nX_full: {X_full.columns.tolist()}')   
-    
+    print(f'\n\n\nX_train: {X_train.columns.tolist()}\n\nX_test: {X_test.columns.tolist()}\n\nX_full: {X_full.columns.tolist()}')
+
     X_train_sel = X_train[selected_cols]
     X_test_sel = X_test[selected_cols]
     X_full_sel = X_full[selected_cols]
 
     models = load_models(MODEL_DIR)
-    
+
     print(f"\n\nModels loaded from {MODEL_DIR}:\n{list(models.keys())}\n\n")
-       
+
     final_predictions(df, X_full_sel, y_full, X_test_sel, y_test, models,
                       top_n=10, output_csv=path_sffs)
 
@@ -68,4 +82,7 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser(description='Gera previsões usando modelos treinados')
+    parser.add_argument('--full', action='store_true', help='Usa modelos treinados com todas as features')
+    args = parser.parse_args()
+    main(full=args.full)


### PR DESCRIPTION
## Summary
- add argparse support in `predict_models.py`
- allow predicting models trained with all features
- document the `--full` option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f6622d62c832cb9804a7b8de8fbbb